### PR TITLE
fix: types for optional stores

### DIFF
--- a/package/types.ts
+++ b/package/types.ts
@@ -70,22 +70,22 @@ export type HocFunc<S, R extends ComponentClass<any> = ComponentClass<any>> = (
 export type Listener<S extends Store> = (params: Params<S>) => void;
 
 export type getStoreType<S extends Store> = {
-  [key in keyof S]: S[key] extends Store
+  [key in keyof S]-?: NonNullable<S[key]> extends Store
     ? useStoreType<S[key]> & HookDry<S[key]> : HookDry<S[key]>;
 };
 
 export type setStoreType<S extends Store> = {
-  [key in keyof S]: S[key] extends Store
+  [key in keyof S]-?: NonNullable<S[key]> extends Store
     ? setStoreType<S[key]> & Setter<S[key]> : Setter<S[key]>;
 };
 
 export type useStoreType<S extends Store> = {
-  [key in keyof S]: S[key] extends Store
+  [key in keyof S]-?: NonNullable<S[key]> extends Store
     ? useStoreType<S[key]> & Hook<S[key]> : Hook<S[key]>;
 };
 
 export type withStoreType<S extends Store> = {
-  [key in keyof S]: S[key] extends Store
+  [key in keyof S]-?: NonNullable<S[key]> extends Store
     ? withStoreType<S[key]> & HocFunc<S[key]>
     : HocFunc<S[key]>;
 };

--- a/package/types.ts
+++ b/package/types.ts
@@ -71,7 +71,7 @@ export type Listener<S extends Store> = (params: Params<S>) => void;
 
 export type getStoreType<S extends Store> = {
   [key in keyof S]-?: NonNullable<S[key]> extends Store
-    ? useStoreType<S[key]> & HookDry<S[key]> : HookDry<S[key]>;
+    ? getStoreType<S[key]> & HookDry<S[key]> : HookDry<S[key]>;
 };
 
 export type setStoreType<S extends Store> = {

--- a/tests/useStore.test.tsx
+++ b/tests/useStore.test.tsx
@@ -203,4 +203,41 @@ describe('useStore', () => {
         .toMatchObject({cart: {items: [{name: 'new Item', price: 2}, undefined, {name: 'new Item', price: 1}]}});
     expect(screen.getByTestId('item').textContent).toBe('Item: {"name":"new Item","price":1}');
   });
+
+  it("should work with optional properties", () => {
+    type User = {
+      username: string;
+    };
+
+    type Store = {
+      user?: User;
+    };
+
+    const { useStore, getStore } = createStore<Store>();
+
+    function Test() {
+      const [user] = useStore.user();
+      const [username] = useStore.user.username();
+      return (
+        <>
+          <div data-testid="username">{username}</div>
+          <div data-testid="user">{JSON.stringify(user)}</div>
+        </>
+      );
+    }
+
+    render(<Test />);
+
+    const update = getStore.user.username()[1];
+
+    expect(screen.getByTestId("username").textContent).toBe("");
+
+    act(() => update('myUsername'));
+    expect(screen.getByTestId("username").textContent).toBe("myUsername");
+    expect(screen.getByTestId("user").textContent).toBe('{"username":"myUsername"}');
+
+    act(() => update((v) => v + "Update"));
+    expect(screen.getByTestId("username").textContent).toBe("myUsernameUpdate");
+    expect(screen.getByTestId("user").textContent).toBe('{"username":"myUsernameUpdate"}');
+  });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Changed the types of `getStoreType`, `useStoreType`, `setStoreType` and `withStoreType` to accept stores where some keys are optional.

**Which issue (if any) does this pull request address?**

I didn't open an issue beforehand, but I'll try to explain the issue. Imagine we have the following store:
```ts
type User = {
  username: string;
  avatar: string | undefined;
}

type Store = {
  user: User | undefined
}

const { useStore, getStore, withStore, setStore } = createStore<Store>()
```

The following function calls are marked as invalid by TypeScript, but do work through the Proxy:
```ts
setStore.user.username() // Property 'username' does not exist on type 'setter<User | undefined>'.
getStore.user.username() // Property 'username' does not exist on type 'HookDry<User | undefined>'.
useStore.user.username() // Property 'username' does not exist on type 'Hook<User | undefined>'.
withStore.user.username() // Property 'username' does not exist on type 'HocFunc<Store, ComponentClass<{}, any>>'.
```

**Is there anything you'd like reviewers to focus on?**

I'm not sure this is the best way to do things, and I'm also not too sure how you'd prefer your types to be for `getStore`, `withStore` and `useStore` for example. This PR changes those as such:
```ts
const [username, setUsername] = getStore.user.username()

typeof username = string;
typeof setUsername = setter<string>
typeof getStore.user = useStoreType<User> & HookDry<User | undefined>
```

I think at least `username` should be `string?` instead of `string` or `getStore.user` should be `Optional<useStoreType<User> & HookDry<User | undefined>>`. The latter makes less sense to me, as technically the code runs and doesn't throw a `Cannot read properties of undefined (reading 'user')` error, but the fact that `username` might be undefined as long a one of its parent keys is `undefined` should be clear.